### PR TITLE
Add Option to Omit Pivot Table Body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
 # Pivot-table-creator
 
-This script generates a pivot table from a CSV file. It supports additional columns, row totals, weekly and monthly totals, and offers various command line options. It is designed for large datasets and is memory-efficient.
+This script generates a pivot table from a CSV file. It supports additional columns, row totals, weekly and monthly totals, and offers various command line options including the ability to omit the main body of the pivot table. It is designed for large datasets and is memory-efficient.
 
 ## Usage
 
 1. Install the required dependencies:
-2. npm install
-3. Run the script with the desired options:
+    ```sh
+    npm install
+    ```
 
-$ node index.js -- [options]
+2. Run the script with the desired options:
+    ```sh
+    node index.js -- [options]
+    ```
 
 ## Available options:
 
-- -i, --input <inputFile>: Input CSV file path (default: "input.csv")
-- -o, --output <outputFile>: Output CSV file path (default: "output.csv")
-- -r, --rowDimension <rowIndex>: Row dimension column index (default: 0)
-- -c, --columnDimension <columnIndex>: Column dimension column index (default: 1)
-- -v, --valueDimension <valueIndex>: Value dimension column index (default: 2)
-- -e, --extraColumns <columnIndexes>: Additional column indexes to be included (default: "")
-- --rowTotals: Include row totals in the output (default: false)
+- `-i, --input <inputFile>`: Input CSV file path (default: "input.csv")
+- `-o, --output <outputFile>`: Output CSV file path (default: "output.csv")
+- `-r, --rowDimension <rowIndex>`: Row dimension column index (default: 0)
+- `-c, --columnDimension <columnIndex>`: Column dimension column index (default: 1)
+- `-v, --valueDimension <valueIndex>`: Value dimension column index (default: 2)
+- `-e, --extraColumns <columnIndexes>`: Additional column indexes to be included (default: "")
+- `--rowTotals`: Include row totals in the output (default: false)
 - `--minRowTotal <minRowTotal>`: Minimum row total for inclusion in the output (default: null)
 - `--maxRowTotal <maxRowTotal>`: Maximum row total for inclusion in the output (default: null)
 - `--weeklyTotals`: Include weekly totals in the output based on the USA calendar system where weeks start on Sunday (default: false)
 - `--monthlyTotals`: Include monthly totals in the output (default: false)
+- `--omitBody`: Omit the main body of the pivot table and include only the totals (default: false)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -112,9 +112,12 @@ async function main() {
   // Existing header definition
   const header = [["Row \\ Column"]];
 
-  // Add extra column headers only if omitBody is not set
+  // Always add extra column headers
+  header[0].push(...extraColumns.map(col => `Extra Col ${col}`));
+
+  // Add main column headers only if omitBody is not set
   if (!options.omitBody) {
-    header[0].push(...extraColumns.map(col => `Extra Col ${col}`), ...columns);
+    header[0].push(...columns);
   }
 
   if (options.rowTotals) {

--- a/index.js
+++ b/index.js
@@ -108,7 +108,14 @@ async function main() {
 
   const rows = Array.from(pivotTable.rows).sort();
   const columns = Array.from(pivotTable.columns).sort();
-  const header = [["Row \\ Column", ...extraColumns.map(col => `Extra Col ${col}`), ...columns]];
+
+  // Existing header definition
+  const header = [["Row \\ Column"]];
+
+  // Add extra column headers only if omitBody is not set
+  if (!options.omitBody) {
+    header[0].push(...extraColumns.map(col => `Extra Col ${col}`), ...columns);
+  }
 
   if (options.rowTotals) {
     header[0].push('Row Total');

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ async function main() {
     .option('--monthlyTotals', 'Include monthly totals in the output', false)
     .option('--minRowTotal <minRowTotal>', 'Minimum row total for inclusion in the output', null)
     .option('--maxRowTotal <maxRowTotal>', 'Maximum row total for inclusion in the output', null)
+    .option('--omitBody', 'Omit the body of the pivot table and only include totals', false)
     .parse();
 
   const options = program.opts();
@@ -122,7 +123,7 @@ async function main() {
   if (options.monthlyTotals) {
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
     for (const month of months) {
-        header[0].push(`${month} Total`);
+      header[0].push(`${month} Total`);
     }
   }
 
@@ -146,15 +147,25 @@ async function main() {
 
     let rowTotal = 0;
 
-    // Add cell values
+    // Calculate rowTotal regardless of whether the body is omitted
     for (const columnValue of columns) {
       const key = `${rowValue}-${columnValue}`;
       if (pivotTable.values.has(key)) {
         const cellValue = pivotTable.values.get(key);
-        row.push(cellValue);
         rowTotal += cellValue;
-      } else {
-        row.push('');
+      }
+    }
+
+    if (!options.omitBody) {
+      // Existing logic to write the body
+      for (const columnValue of columns) {
+        const key = `${rowValue}-${columnValue}`;
+        if (pivotTable.values.has(key)) {
+          const cellValue = pivotTable.values.get(key);
+          row.push(cellValue);
+        } else {
+          row.push('');
+        }
       }
     }
 


### PR DESCRIPTION
## Description
This PR introduces a new command-line option --omitBody to the CSV to Pivot Table converter. When this option is enabled, the output CSV file will contain only the row totals, weekly totals, and monthly totals, omitting the main body of the pivot table. This feature can be useful in scenarios where only aggregated data is required.

## Changes
Add a new command-line option --omitBody.
Modify the pivot table header to adapt to the --omitBody setting.
Update the body of the pivot table to conditionally include/exclude columns based on the --omitBody setting.