### PR TITLE
Fix: Ignore Non-Numeric Cell Values in PivotTableGenerator

### DIFF
--- a/pivotTableGenerator.js
+++ b/pivotTableGenerator.js
@@ -31,6 +31,11 @@ class PivotTableGenerator {
       const columnValue = data[i][this.options.columnDimension];
       const cellValue = parseFloat(data[i][this.options.valueDimension]);
 
+      // 数値でないセル値を無視
+      if (isNaN(cellValue)) {
+        continue;
+      }
+
       this.pivotTable.rows.add(rowValue);
       this.pivotTable.columns.add(columnValue);
 

--- a/test/pivotTableGenerator.test.js
+++ b/test/pivotTableGenerator.test.js
@@ -36,4 +36,34 @@ describe('PivotTableGenerator', function() {
       expect(header[0]).to.include.members(['Extra Col 1', 'Extra Col 2']);
     });
   });
+
+  describe('#processData()', function() {
+    it('should ignore non-numeric cell values and not produce NaN in the pivot table', function() {
+      const sampleData = [
+        ['Row', 'Column', 'Value'],
+        ['A', '2023-01-01', '10'],
+        ['A', '2023-01-02', 'not-a-number'],
+        ['B', '2023-01-01', '20'],
+        ['B', '2023-01-02', '30']
+      ];
+
+      const options = {
+        rowDimension: 0,
+        columnDimension: 1,
+        valueDimension: 2,
+        weeklyTotals: true,
+        monthlyTotals: true
+      };
+
+      const generator = new PivotTableGenerator(options);
+      generator.processData(sampleData);
+
+      // Check if the value for 'A-2023-01-02' is ignored and not producing NaN
+      expect(generator.pivotTable.values.get('A-2023-01-02')).to.be.undefined;
+
+      // Check if weekly and monthly totals are not NaN
+      expect(generator.pivotTable.weeklyTotals.get('week-1-A')).to.equal(10);
+      expect(generator.pivotTable.monthlyTotals.get('month-1-A')).to.equal(10);
+    });
+  });
 });


### PR DESCRIPTION
## Overview
This pull request addresses an issue in the `PivotTableGenerator` where non-numeric cell values were causing `NaN` outputs in the generated pivot table.

## Changes
- Modified the `processData` method to check if the cell value is numeric. Non-numeric values are now ignored.
- Added a test to ensure that non-numeric values are properly ignored and do not produce `NaN` in the pivot table.

## Testing
All tests have been run and passed, confirming that the issue has been resolved.

Please review and let me know if there are any further changes needed.
